### PR TITLE
Add helper method to get a struct message as JSON

### DIFF
--- a/eip712_structs/types.py
+++ b/eip712_structs/types.py
@@ -1,8 +1,9 @@
 import re
+from json import JSONEncoder
 from typing import Any, Union, Type
 
 from eth_utils.crypto import keccak
-from eth_utils.conversions import to_int
+from eth_utils.conversions import to_bytes, to_hex, to_int
 
 
 class EIP712Type:
@@ -124,6 +125,10 @@ class Bytes(EIP712Type):
 
     def _encode_value(self, value):
         """Static bytesN types are encoded by right-padding to 32 bytes. Dynamic bytes types are keccak256 hashed."""
+        if isinstance(value, str):
+            # Try converting to a bytestring, assuming that it's been given as hex
+            value = to_bytes(hexstr=value)
+
         if self.length == 0:
             return keccak(value)
         else:
@@ -229,3 +234,11 @@ def from_solidity_type(solidity_type: str):
         return result
     else:
         return type_instance
+
+
+class BytesJSONEncoder(JSONEncoder):
+    def default(self, o):
+        if isinstance(o, bytes):
+            return to_hex(o)
+        else:
+            return super(BytesJSONEncoder, self).default(o)

--- a/tests/test_encode_data.py
+++ b/tests/test_encode_data.py
@@ -187,3 +187,44 @@ def test_validation_errors():
         bool_type.encode_value(0)
     with pytest.raises(ValueError, match='Must be True or False.'):
         bool_type.encode_value(1)
+
+
+def test_struct_eq():
+    class Foo(EIP712Struct):
+        s = String()
+    foo = Foo(s='hello world')
+    foo_copy = Foo(s='hello world')
+    foo_2 = Foo(s='blah')
+
+    assert foo == foo
+    assert foo is not foo_copy
+    assert foo == foo_copy
+    assert foo != foo_2
+
+    def make_different_foo():
+        # We want another struct defined with the same name but different member types
+        class Foo(EIP712Struct):
+            b = Bytes()
+        return Foo
+
+    def make_same_foo():
+        # For good measure, recreate the exact same class and ensure they can still compare
+        class Foo(EIP712Struct):
+            s = String()
+        return Foo
+
+    OtherFooClass = make_different_foo()
+    wrong_type = OtherFooClass(b=b'hello world')
+    assert wrong_type != foo
+    assert OtherFooClass != Foo
+
+    SameFooClass = make_same_foo()
+    right_type = SameFooClass(s='hello world')
+    assert right_type == foo
+    assert SameFooClass != Foo
+
+    # Different name, same members
+    class Bar(EIP712Struct):
+        s = String()
+    bar = Bar(s='hello world')
+    assert bar != foo

--- a/tests/test_encode_data.py
+++ b/tests/test_encode_data.py
@@ -196,6 +196,9 @@ def test_struct_eq():
     foo_copy = Foo(s='hello world')
     foo_2 = Foo(s='blah')
 
+
+    assert foo != None
+    assert foo != 'unrelated type'
     assert foo == foo
     assert foo is not foo_copy
     assert foo == foo_copy

--- a/tests/test_message_json.py
+++ b/tests/test_message_json.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+import pytest
+
 from eip712_structs import EIP712Struct, String, make_domain, Bytes
 
 
@@ -125,3 +127,12 @@ def test_bytes_json_encoder():
     reconstructed = EIP712Struct.from_message(json.loads(result))
     assert reconstructed.domain == domain
     assert reconstructed.message == foo
+
+    class UnserializableObject:
+        pass
+    obj = UnserializableObject()
+
+    # Fabricate this failure case to test that the custom json encoder's fallback path works as expected.
+    foo.values['b'] = obj
+    with pytest.raises(TypeError, match='not JSON serializable'):
+        foo.to_message_json(domain)


### PR DESCRIPTION
Structs containing any Bytes types would error out with the standard `json.dumps` call, since it does not support json-encoding bytes by default.

Major new additions:
- `EIP712Struct().to_message_json()` provides a JSON dump using a custom `JSONEncoder` class which can serialize `bytes` objects into hexstrings.
- The `Bytes` type can now accept a string. Strings are assumed as hexstrings, and are converted into the `bytes` format.
- Additionally, this adds `__eq__` and `__hash__` functions to EIP712Struct - the need arose due to some comparisons I wanted to make during new tests, but it should prove useful to general development efforts.